### PR TITLE
Scope STAC result lookups to fire event (fix slow /result polling)

### DIFF
--- a/src/routers/fire_recovery.py
+++ b/src/routers/fire_recovery.py
@@ -391,9 +391,9 @@ async def get_fire_severity_result(
             command_name=job_result.command_name,
         )
 
-    # Look up the STAC item
-    stac_item = await stac_manager.get_item_by_id(
-        f"{fire_event_name}-severity-{job_id}"
+    # Look up the STAC item (scoped to this fire event to avoid a full-bucket scan)
+    stac_item = await stac_manager.get_item_by_fire_event_and_id(
+        fire_event_name, f"{fire_event_name}-severity-{job_id}"
     )
 
     if not stac_item:
@@ -551,10 +551,11 @@ async def get_refine_result(
             command_name=job_result.command_name,
         )
 
-    # Look up the STAC item
+    # Look up the STAC item (scoped to this fire event to avoid a full-bucket scan)
     boundary_stac_item = await stac_manager.get_items_by_id_and_coarseness(
         f"{fire_event_name}-boundary-{job_id}",
         "refined",
+        fire_event_name=fire_event_name,
     )
 
     if not boundary_stac_item:
@@ -579,6 +580,7 @@ async def get_refine_result(
     severity_stac_item = await stac_manager.get_items_by_id_and_coarseness(
         f"{fire_event_name}-severity-{job_id}",
         "refined",
+        fire_event_name=fire_event_name,
     )
 
     if not severity_stac_item:
@@ -962,10 +964,11 @@ async def get_veg_map_result(
             command_name=job_result.command_name,
         )
 
-    # Look up the STAC item
+    # Look up the STAC item (scoped to this fire event to avoid a full-bucket scan)
     stac_item = await stac_manager.get_items_by_id_and_classification_breaks(
         f"{fire_event_name}-veg-matrix-{job_id}",
         classification_breaks=severity_breaks,
+        fire_event_name=fire_event_name,
     )
 
     if not stac_item:

--- a/src/stac/stac_json_manager.py
+++ b/src/stac/stac_json_manager.py
@@ -185,19 +185,25 @@ class STACJSONManager:
         return await self._repository.get_items_by_fire_event(fire_event_name)
 
     async def get_items_by_id_and_coarseness(
-        self, item_id: str, boundary_type: str
+        self,
+        item_id: str,
+        boundary_type: str,
+        fire_event_name: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Get a STAC item by ID and boundary type"""
         return await self._repository.get_items_by_id_and_coarseness(
-            item_id, boundary_type
+            item_id, boundary_type, fire_event_name
         )
 
     async def get_items_by_id_and_classification_breaks(
-        self, item_id: str, classification_breaks: Optional[List[float]] = None
+        self,
+        item_id: str,
+        classification_breaks: Optional[List[float]] = None,
+        fire_event_name: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Get a STAC item by ID and classification breaks"""
         return await self._repository.get_items_by_id_and_classification_breaks(
-            item_id, classification_breaks
+            item_id, classification_breaks, fire_event_name
         )
 
     async def search_items(

--- a/src/stac/stac_json_repository.py
+++ b/src/stac/stac_json_repository.py
@@ -149,13 +149,19 @@ class STACJSONRepository:
         return items
 
     async def get_items_by_id_and_coarseness(
-        self, item_id: str, boundary_type: str
+        self,
+        item_id: str,
+        boundary_type: str,
+        fire_event_name: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Retrieve a specific STAC item by ID and boundary type
+
+        When fire_event_name is provided, the search is scoped to that fire event's
+        prefix instead of scanning the entire catalog.
         """
-        # This requires searching through files - could be optimized with indexing later
-        all_files = await self.storage.list_files("stac/")
+        prefix = f"stac/{fire_event_name}/" if fire_event_name else "stac/"
+        all_files = await self.storage.list_files(prefix)
 
         for file_path in all_files:
             if file_path.endswith(".json"):
@@ -173,12 +179,19 @@ class STACJSONRepository:
         return None
 
     async def get_items_by_id_and_classification_breaks(
-        self, item_id: str, classification_breaks: Optional[List[float]] = None
+        self,
+        item_id: str,
+        classification_breaks: Optional[List[float]] = None,
+        fire_event_name: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Retrieve a specific STAC item by ID and classification breaks
+
+        When fire_event_name is provided, the search is scoped to that fire event's
+        prefix instead of scanning the entire catalog.
         """
-        all_files = await self.storage.list_files("stac/")
+        prefix = f"stac/{fire_event_name}/" if fire_event_name else "stac/"
+        all_files = await self.storage.list_files(prefix)
 
         for file_path in all_files:
             if file_path.endswith(".json"):


### PR DESCRIPTION
> 🤖 **Claude PR** — authored by Claude Code.

## Problem
Fire severity polling from the dev frontend was failing with a browser `CORS request did not succeed (Status: null)` ~30s after the request. The origin (`https://storage.googleapis.com`) is already allow-listed in `src/app.py` — the `null` status after 30s is a **timeout/dropped request**, not an origin rejection: when the response never arrives, no CORS headers are attached and the browser reports a generic CORS error.

The root cause is on the retrieval path. The `/result/*` endpoints looked up STAC items with methods that **list every object under `stac/` and download each JSON** to match one id — an O(n) network scan per poll that grows with the bucket and can hang long enough for the request to be dropped.

## Fix
Each result endpoint already has `fire_event_name` in its path, so scope the lookup to the `stac/{fire_event_name}/` prefix instead of scanning the whole catalog:

- `GET /result/analyze_fire_severity/...` → `get_item_by_fire_event_and_id`
- `GET /result/refine/...` → `get_items_by_id_and_coarseness(..., fire_event_name=...)`
- `GET /result/resolve_against_veg_map/...` → `get_items_by_id_and_classification_breaks(..., fire_event_name=...)`

`fire_event_name` was added as a **trailing optional arg** on the coarseness / classification-breaks methods (repository + manager passthrough), so existing callers are unaffected.

## Notes / out of scope
- The CORS config itself was not changed — the frontend origin is already allow-listed.
- A second suspect for slow/dropped polls is **Cloud Run CPU throttling of FastAPI `BackgroundTasks`** (heavy processing runs in-process after the response returns, and CPU is throttled unless "CPU always allocated" is set). Not addressed here.
- Internal command-side lookups in `vegetation_resolve_command` / `boundary_refinement_command` still use unscoped methods; left as-is since they're background, not on the latency-critical poll path.

## Testing
`pytest tests/stac/test_stac_json_repository.py tests/stac/test_stac_json_manager_minio.py tests/api` → 24 passed, 7 skipped. `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)