### PR TITLE
Add Landsat support alongside Sentinel-2 via sensor toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fire Recovery Backend
 
-A FastAPI service for fire severity analysis, boundary refinement, and vegetation impact assessment using Sentinel-2 satellite imagery. 
+A FastAPI service for fire severity analysis, boundary refinement, and vegetation impact assessment using Sentinel-2 or Landsat satellite imagery. 
 
 Part of the [DSE Disturbance Toolbox](https://dse-disturbance-toolbox.org/tools/disturbance-severity/methodology/).
 
@@ -8,7 +8,7 @@ Part of the [DSE Disturbance Toolbox](https://dse-disturbance-toolbox.org/tools/
 
 This API processes satellite imagery to help assess wildfire impacts:
 
-1. **Fire Severity Analysis** - Calculates burn severity indices (NBR, dNBR, RdNBR, RBR) from Sentinel-2 imagery
+1. **Fire Severity Analysis** - Calculates burn severity indices (NBR, dNBR, RdNBR, RBR) from Sentinel-2 or Landsat imagery
 2. **Boundary Refinement** - Crops analysis to user-drawn boundaries for precise impact areas
 3. **Vegetation Impact** - Generates statistics on fire effects across vegetation communities
 
@@ -76,7 +76,7 @@ Interactive API docs available at `/docs` (Swagger UI) or `/redoc` when running 
 ## Technology Stack
 
 - **FastAPI** - Async Python web framework
-- **Sentinel-2 L2A** - Satellite imagery via Microsoft Planetary Computer
+- **Sentinel-2 L2A & Landsat C2 L2** - Satellite imagery via Element 84 and Microsoft Planetary Computer
 - **Cloud Optimized GeoTIFF** - Web-optimized raster format
 - **STAC** - SpatioTemporal Asset Catalog for metadata
 - **Google Cloud Storage** - Asset storage (S3-compatible)

--- a/config/stac_providers.json
+++ b/config/stac_providers.json
@@ -1,20 +1,52 @@
 {
-  "providers": [
-    {
-      "id": "ELEMENT_84",
-      "name": "Element 84",
-      "url": "https://earth-search.aws.element84.com/v1/",
-      "swir_band": "swir22",
-      "nir_band": "nir08",
-      "epsg_code": 4326
+  "sensors": {
+    "sentinel-2": {
+      "providers": [
+        {
+          "id": "ELEMENT_84",
+          "name": "Element 84",
+          "url": "https://earth-search.aws.element84.com/v1/",
+          "collection": "sentinel-2-l2a",
+          "swir_band": "swir22",
+          "nir_band": "nir08",
+          "epsg_code": 4326
+        },
+        {
+          "id": "MICROSOFT_PLANETARY_COMPUTER",
+          "name": "Microsoft Planetary Computer",
+          "url": "https://planetarycomputer.microsoft.com/api/stac/v1",
+          "collection": "sentinel-2-l2a",
+          "swir_band": "B12",
+          "nir_band": "B8A",
+          "epsg_code": 4326
+        }
+      ]
     },
-    {
-      "id": "MICROSOFT_PLANETARY_COMPUTER",
-      "name": "Microsoft Planetary Computer",
-      "url": "https://planetarycomputer.microsoft.com/api/stac/v1",
-      "swir_band": "B12",
-      "nir_band": "B8A",
-      "epsg_code": 4326
+    "landsat": {
+      "providers": [
+        {
+          "id": "ELEMENT_84",
+          "name": "Element 84",
+          "url": "https://earth-search.aws.element84.com/v1/",
+          "collection": "landsat-c2-l2",
+          "swir_band": "swir22",
+          "nir_band": "nir08",
+          "epsg_code": 4326,
+          "scale": 0.0000275,
+          "offset": -0.2
+        },
+        {
+          "id": "MICROSOFT_PLANETARY_COMPUTER",
+          "name": "Microsoft Planetary Computer",
+          "url": "https://planetarycomputer.microsoft.com/api/stac/v1",
+          "collection": "landsat-c2-l2",
+          "swir_band": "swir22",
+          "nir_band": "nir08",
+          "epsg_code": 4326,
+          "scale": 0.0000275,
+          "offset": -0.2
+        }
+      ]
     }
-  ]
+  }
 }

--- a/config/stac_providers.json
+++ b/config/stac_providers.json
@@ -25,18 +25,18 @@
     "landsat": {
       "providers": [
         {
-          "id": "ELEMENT_84",
-          "name": "Element 84",
-          "url": "https://earth-search.aws.element84.com/v1/",
+          "id": "MICROSOFT_PLANETARY_COMPUTER",
+          "name": "Microsoft Planetary Computer",
+          "url": "https://planetarycomputer.microsoft.com/api/stac/v1",
           "collection": "landsat-c2-l2",
           "swir_band": "swir22",
           "nir_band": "nir08",
           "epsg_code": 4326
         },
         {
-          "id": "MICROSOFT_PLANETARY_COMPUTER",
-          "name": "Microsoft Planetary Computer",
-          "url": "https://planetarycomputer.microsoft.com/api/stac/v1",
+          "id": "ELEMENT_84",
+          "name": "Element 84",
+          "url": "https://earth-search.aws.element84.com/v1/",
           "collection": "landsat-c2-l2",
           "swir_band": "swir22",
           "nir_band": "nir08",

--- a/config/stac_providers.json
+++ b/config/stac_providers.json
@@ -31,9 +31,7 @@
           "collection": "landsat-c2-l2",
           "swir_band": "swir22",
           "nir_band": "nir08",
-          "epsg_code": 4326,
-          "scale": 0.0000275,
-          "offset": -0.2
+          "epsg_code": 4326
         },
         {
           "id": "MICROSOFT_PLANETARY_COMPUTER",
@@ -42,9 +40,7 @@
           "collection": "landsat-c2-l2",
           "swir_band": "swir22",
           "nir_band": "nir08",
-          "epsg_code": 4326,
-          "scale": 0.0000275,
-          "offset": -0.2
+          "epsg_code": 4326
         }
       ]
     }

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -34,11 +34,11 @@ All endpoints are prefixed with `/fire-recovery/`.
 
 ### POST /process/analyze_fire_severity
 
-Initiates fire severity analysis using Sentinel-2 satellite imagery. This is an async operation that returns immediately with a job ID for polling.
+Initiates fire severity analysis using Sentinel-2 (default) or Landsat satellite imagery, selectable via the `sensor` field. This is an async operation that returns immediately with a job ID for polling.
 
 #### Processing Pipeline
 
-1. Queries Sentinel-2 L2A data from Microsoft Planetary Computer STAC
+1. Queries the selected sensor's collection — Sentinel-2 L2A or Landsat C2 L2 — from STAC (Element 84 primary, Microsoft Planetary Computer fallback)
 2. Creates temporal median composites for pre-fire and post-fire periods
 3. Calculates spectral indices:
    - **NBR** (Normalized Burn Ratio): `(NIR - SWIR) / (NIR + SWIR)`
@@ -66,7 +66,8 @@ curl -X POST "http://localhost:8000/fire-recovery/process/analyze_fire_severity"
       ]]
     },
     "prefire_date_range": ["2023-06-01", "2023-06-09"],
-    "postfire_date_range": ["2023-06-17", "2023-06-22"]
+    "postfire_date_range": ["2023-06-17", "2023-06-22"],
+    "sensor": "sentinel-2"
   }'
 ```
 
@@ -78,6 +79,7 @@ curl -X POST "http://localhost:8000/fire-recovery/process/analyze_fire_severity"
 | `coarse_geojson` | GeoJSON | Yes | Polygon, MultiPolygon, or Feature defining the area of interest |
 | `prefire_date_range` | string[] | Yes | Two ISO dates `[start, end]` for pre-fire imagery (2-3 weeks before ignition) |
 | `postfire_date_range` | string[] | Yes | Two ISO dates `[start, end]` for post-fire imagery (2-3 weeks after containment) |
+| `sensor` | string | No | Satellite source: `sentinel-2` (default) or `landsat` |
 
 #### Response (202 Accepted)
 

--- a/src/commands/impl/fire_severity_command.py
+++ b/src/commands/impl/fire_severity_command.py
@@ -231,10 +231,9 @@ class FireSeverityAnalysisCommand(Command):
 
             logger.info(f"Found {len(items)} STAC items for analysis")
 
-            # Get band configuration and reflectance scaling for the matched provider
+            # Get band configuration for the matched provider
             nir_band, swir_band = stac_handler.get_band_names(endpoint_config)
             epsg_code = stac_handler.get_epsg_code(endpoint_config)
-            scale, offset = stac_handler.get_reflectance_scaling(endpoint_config)
 
             logger.info(
                 f"Resolved collection: {endpoint_config.collection} | bands - "
@@ -249,23 +248,23 @@ class FireSeverityAnalysisCommand(Command):
                 geometry_dict: Dict[str, Any] = geometry  # type: ignore
             buffered_bounds = self._get_buffered_bounds(geometry_dict, buffer_meters)
 
-            # Stack data using stackstac
+            # Stack data using stackstac. rescale=True (stackstac's default, made
+            # explicit here because we depend on it) applies the per-asset
+            # scale/offset from each item's `raster:bands` STAC metadata, yielding
+            # surface reflectance, and masks nodata to NaN. This is what makes
+            # Landsat C2 L2 — stored as scaled integers with a -0.2 offset —
+            # comparable to Sentinel-2: NBR's normalized difference cancels a
+            # multiplicative scale but NOT the additive offset, so the offset must
+            # be applied. We rely on the providers' published metadata to do this
+            # rather than hardcoding per-sensor reflectance constants.
             stacked_data = stackstac.stack(
                 items,
                 epsg=epsg_code,
                 assets=[swir_band, nir_band],
                 bounds=buffered_bounds,
                 chunksize=(-1, 1, 512, 512),
+                rescale=True,
             )
-
-            # Convert stored DN values to surface reflectance for sensors that
-            # store scaled integers (e.g. Landsat C2 L2). NBR is a normalized
-            # difference, so the multiplicative scale cancels but the additive
-            # offset does NOT — without this, Landsat dNBR/RBR are not comparable
-            # to Sentinel-2. Defaults (1.0, 0.0) make this a no-op for Sentinel-2.
-            if scale != 1.0 or offset != 0.0:
-                logger.info(f"Applying reflectance scaling: value * {scale} + {offset}")
-                stacked_data = stacked_data * scale + offset
 
             # Split into pre and post fire datasets
             prefire_data = self._subset_data_by_date_range(

--- a/src/commands/impl/fire_severity_command.py
+++ b/src/commands/impl/fire_severity_command.py
@@ -115,7 +115,7 @@ class FireSeverityAnalysisCommand(Command):
             # Extract configuration
             prefire_date_range = context.get_computation_config("prefire_date_range")
             postfire_date_range = context.get_computation_config("postfire_date_range")
-            collection = context.get_computation_config("collection", "sentinel-2-l2a")
+            sensor = context.get_computation_config("sensor", "sentinel-2")
             buffer_meters = context.get_computation_config("buffer_meters", 100)
             indices = context.get_computation_config(
                 "indices",
@@ -132,7 +132,7 @@ class FireSeverityAnalysisCommand(Command):
 
             logger.info(
                 f"Configuration - Prefire: {prefire_date_range}, "
-                f"Postfire: {postfire_date_range}, Collection: {collection}, "
+                f"Postfire: {postfire_date_range}, Sensor: {sensor}, "
                 f"Buffer: {buffer_meters}m, Indices: {indices}"
             )
 
@@ -142,7 +142,7 @@ class FireSeverityAnalysisCommand(Command):
                 geometry,
                 prefire_date_range,
                 postfire_date_range,
-                collection,
+                sensor,
                 buffer_meters,
             )
 
@@ -204,7 +204,7 @@ class FireSeverityAnalysisCommand(Command):
         geometry: Polygon | MultiPolygon | Feature,
         prefire_date_range: List[str],
         postfire_date_range: List[str],
-        collection: str,
+        sensor: str,
         buffer_meters: float,
     ) -> STACDataPayload:
         """Fetch satellite data for pre and post-fire periods"""
@@ -217,11 +217,11 @@ class FireSeverityAnalysisCommand(Command):
             # Calculate full date range for single query
             full_date_range = [prefire_date_range[0], postfire_date_range[1]]
 
-            # Search for items
+            # Search for items (provider chain + collection resolved per sensor)
             items, endpoint_config = await stac_handler.search_items(
                 geometry=geometry,
                 date_range=full_date_range,
-                collections=[collection],
+                sensor=sensor,
             )
 
             if not items:
@@ -231,12 +231,14 @@ class FireSeverityAnalysisCommand(Command):
 
             logger.info(f"Found {len(items)} STAC items for analysis")
 
-            # Get band configuration
+            # Get band configuration and reflectance scaling for the matched provider
             nir_band, swir_band = stac_handler.get_band_names(endpoint_config)
             epsg_code = stac_handler.get_epsg_code(endpoint_config)
+            scale, offset = stac_handler.get_reflectance_scaling(endpoint_config)
 
             logger.info(
-                f"Using bands - NIR: {nir_band}, SWIR: {swir_band}, EPSG: {epsg_code}"
+                f"Resolved collection: {endpoint_config.collection} | bands - "
+                f"NIR: {nir_band}, SWIR: {swir_band}, EPSG: {epsg_code}"
             )
 
             # Calculate buffered bounds
@@ -255,6 +257,15 @@ class FireSeverityAnalysisCommand(Command):
                 bounds=buffered_bounds,
                 chunksize=(-1, 1, 512, 512),
             )
+
+            # Convert stored DN values to surface reflectance for sensors that
+            # store scaled integers (e.g. Landsat C2 L2). NBR is a normalized
+            # difference, so the multiplicative scale cancels but the additive
+            # offset does NOT — without this, Landsat dNBR/RBR are not comparable
+            # to Sentinel-2. Defaults (1.0, 0.0) make this a no-op for Sentinel-2.
+            if scale != 1.0 or offset != 0.0:
+                logger.info(f"Applying reflectance scaling: value * {scale} + {offset}")
+                stacked_data = stacked_data * scale + offset
 
             # Split into pre and post fire datasets
             prefire_data = self._subset_data_by_date_range(

--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -1,6 +1,11 @@
-from typing import List, Union, Optional
+from typing import List, Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field
 from geojson_pydantic import Polygon, MultiPolygon, Feature
+
+# Supported satellite sources for fire severity analysis. Adding a value here
+# (plus a matching sensor entry in config/stac_providers.json) is all that is
+# needed to expose a new sensor through the API.
+Sensor = Literal["sentinel-2", "landsat"]
 
 
 class ProcessingRequest(BaseModel):
@@ -24,6 +29,7 @@ class ProcessingRequest(BaseModel):
                 },
                 "prefire_date_range": ["2023-06-01", "2023-06-09"],
                 "postfire_date_range": ["2023-06-17", "2023-06-22"],
+                "sensor": "sentinel-2",
             }
         }
     )
@@ -40,6 +46,10 @@ class ProcessingRequest(BaseModel):
     postfire_date_range: list[str] = Field(
         ...,
         description="Date range for postfire imagery [start, end] (2-3 weeks after containment)",
+    )
+    sensor: Sensor = Field(
+        default="sentinel-2",
+        description="Satellite source to analyze: 'sentinel-2' (default) or 'landsat'",
     )
 
 

--- a/src/routers/fire_recovery.py
+++ b/src/routers/fire_recovery.py
@@ -246,9 +246,10 @@ async def analyze_fire_severity(
     index_registry: IndexRegistry = Depends(get_index_registry),
 ) -> ProcessingStartedResponse:
     """
-    Initiate fire severity analysis using Sentinel-2 satellite imagery.
+    Initiate fire severity analysis using Sentinel-2 (default) or Landsat satellite imagery.
 
-    Calculates NBR, dNBR, RdNBR, and RBR indices. Returns immediately with a job ID for polling.
+    Select the source via the optional `sensor` body field. Calculates NBR, dNBR,
+    RdNBR, and RBR indices. Returns immediately with a job ID for polling.
 
     See [docs/ENDPOINTS.md#post-processanalyze_fire_severity](https://github.com/SchmidtDSE/fire-recovery-backend/blob/main/docs/ENDPOINTS.md#post-processanalyze_fire_severity) for details.
     """
@@ -263,6 +264,7 @@ async def analyze_fire_severity(
         geometry=request.coarse_geojson,
         prefire_date_range=request.prefire_date_range,
         postfire_date_range=request.postfire_date_range,
+        sensor=request.sensor,
         stac_manager=stac_manager,
         storage_factory=storage_factory,
         index_registry=index_registry,
@@ -284,6 +286,7 @@ async def process_fire_severity(
     stac_manager: STACJSONManager,
     storage_factory: StorageFactory,
     index_registry: IndexRegistry,
+    sensor: str = "sentinel-2",
 ) -> None:
     logger = logging.getLogger(__name__)
     start_time = time.time()
@@ -301,7 +304,7 @@ async def process_fire_severity(
             computation_config={
                 "prefire_date_range": prefire_date_range,
                 "postfire_date_range": postfire_date_range,
-                "collection": "sentinel-2-l2a",
+                "sensor": sensor,
                 "buffer_meters": 100,
                 "indices": ["dnbr", "rdnbr", "rbr"],
             },

--- a/src/stac/stac_endpoint_handler.py
+++ b/src/stac/stac_endpoint_handler.py
@@ -9,6 +9,12 @@ import logging
 from geojson_pydantic import Polygon, MultiPolygon, Feature
 
 
+# Default sensor used when a caller does not specify one. Kept as a module
+# constant so the request model, router, and command can share a single source
+# of truth for the fallback.
+DEFAULT_SENSOR = "sentinel-2"
+
+
 class StacProvider(Enum):
     """Enum for STAC providers."""
 
@@ -17,18 +23,37 @@ class StacProvider(Enum):
 
 
 class StacMapping(BaseModel):
-    """Model for STAC mapping configuration."""
+    """
+    Model for a single (sensor, provider) STAC mapping.
+
+    The collection ID and band names are properties of the *(sensor, provider)*
+    pair, not of the provider alone, so they live together on this model. The
+    reflectance ``scale``/``offset`` default to a no-op; sensors whose surface
+    reflectance is stored as scaled integers (e.g. Landsat Collection-2 Level-2)
+    override them so values become comparable across sensors.
+    """
 
     id: StacProvider
     name: str
     url: str
+    collection: str
     swir_band: str
     nir_band: str
     epsg_code: int
+    scale: float = 1.0
+    offset: float = 0.0
+
+
+class SensorConfig(BaseModel):
+    """Ordered fallback chain of provider mappings for a single sensor."""
+
+    providers: List[StacMapping]
 
 
 class StacProviderConfig(BaseModel):
-    providers: List[StacMapping]
+    """Top-level configuration: a set of sensors, each with its own providers."""
+
+    sensors: Dict[str, SensorConfig]
 
     @classmethod
     def load_from_file(
@@ -39,32 +64,57 @@ class StacProviderConfig(BaseModel):
             with open(filepath, "r") as f:
                 data = json.load(f)
 
-            # Convert string representation of enum to actual enum
-            for provider in data.get("providers", []):
-                if isinstance(provider.get("id"), str):
-                    try:
-                        provider["id"] = StacProvider[provider["id"]]
-                    except KeyError:
-                        raise ValueError(f"Unknown provider: {provider['id']}")
+            # Convert the string representation of the provider enum to the
+            # actual enum for every provider under every sensor.
+            for sensor_cfg in data.get("sensors", {}).values():
+                for provider in sensor_cfg.get("providers", []):
+                    if isinstance(provider.get("id"), str):
+                        try:
+                            provider["id"] = StacProvider[provider["id"]]
+                        except KeyError:
+                            raise ValueError(f"Unknown provider: {provider['id']}")
 
             return cls.model_validate(data)
         except FileNotFoundError:
             raise FileNotFoundError(f"Configuration file {filepath} not found.")
 
-    def get_providers(self) -> List[StacMapping]:
+    def get_sensors(self) -> List[str]:
         """
-        Get the providers as a list.
+        Get the configured sensor keys.
 
         Returns:
-            List of provider configurations.
+            List of sensor names (e.g. ["sentinel-2", "landsat"]).
         """
-        return self.providers
+        return list(self.sensors.keys())
+
+    def get_providers(self, sensor: str = DEFAULT_SENSOR) -> List[StacMapping]:
+        """
+        Get the ordered providers for a given sensor.
+
+        Args:
+            sensor: Sensor key selecting which provider chain to use.
+
+        Returns:
+            Ordered list of provider configurations for the sensor.
+
+        Raises:
+            ValueError: If the sensor is not configured.
+        """
+        if sensor not in self.sensors:
+            raise ValueError(
+                f"Unknown sensor '{sensor}'. Available sensors: "
+                f"{sorted(self.sensors.keys())}"
+            )
+        return self.sensors[sensor].providers
 
 
 class StacEndpointHandler:
     """
     Handles interactions with STAC endpoints with fallback support.
-    Tries multiple STAC endpoints in order of priority when data is not available.
+
+    Tries multiple STAC endpoints in order of priority when data is not
+    available. Providers, their collection IDs, band names, and reflectance
+    scaling are all resolved per sensor from configuration.
     """
 
     def __init__(
@@ -77,10 +127,12 @@ class StacEndpointHandler:
         Args:
             stac_provider_json_path: Path to the STAC provider configuration JSON file.
         """
-        self.providers = StacProviderConfig.load_from_file(
-            stac_provider_json_path
-        ).get_providers()
+        self.config = StacProviderConfig.load_from_file(stac_provider_json_path)
         self.logger = logging.getLogger(__name__)
+
+    def get_sensors(self) -> List[str]:
+        """Get the configured sensor keys."""
+        return self.config.get_sensors()
 
     async def get_client(
         self, provider: StacMapping
@@ -109,53 +161,60 @@ class StacEndpointHandler:
         self,
         geometry: Polygon | MultiPolygon | Feature | Dict[str, Any],
         date_range: List[str],
-        collections: Optional[List[str]] = None,
+        sensor: str = DEFAULT_SENSOR,
         provider_index: Optional[int] = None,
     ) -> Tuple[ItemCollection, StacMapping]:
         """
-        Search for items using STAC providers.
+        Search for items using the STAC providers configured for a sensor.
 
         Args:
             geometry: GeoJSON geometry to search within (Polygon, MultiPolygon, Feature, or dict)
             date_range: List of [start_date, end_date] as strings
-            collections: List of collection IDs to search
+            sensor: Sensor key selecting the provider chain and collection to query
             provider_index: Index of provider to use. If None, tries all in order.
 
         Returns:
             Tuple of (items, provider)
 
         Raises:
+            ValueError: If the sensor is unknown or provider_index is out of range
             RuntimeError: If no items found at any provider
         """
-        search_params: Dict[str, Any] = {
+        providers = self.config.get_providers(sensor)
+
+        base_params: Dict[str, Any] = {
             "intersects": geometry,
             "datetime": "/".join(date_range),
         }
 
-        if collections:
-            search_params["collections"] = collections
-
         if provider_index is not None:
             # Try specific provider
-            if provider_index < 0 or provider_index >= len(self.providers):
+            if provider_index < 0 or provider_index >= len(providers):
                 raise ValueError(f"Provider index {provider_index} out of range")
 
-            provider = self.providers[provider_index]
+            provider = providers[provider_index]
             client, provider = await self.get_client(provider)
 
-            items = client.search(**search_params).item_collection()
+            items = client.search(
+                **base_params, collections=[provider.collection]
+            ).item_collection()
             if len(items) > 0:
                 return items, provider
             else:
                 raise RuntimeError(f"No items found using provider {provider.name}")
         else:
-            # Try all providers in order
-            for i, provider in enumerate(self.providers):
+            # Try all providers in order (per-sensor fallback chain)
+            for i, provider in enumerate(providers):
                 try:
-                    self.logger.info(f"Trying STAC provider {i}: {provider.name}")
+                    self.logger.info(
+                        f"Trying STAC provider {i}: {provider.name} "
+                        f"(sensor: {sensor}, collection: {provider.collection})"
+                    )
                     client, provider = await self.get_client(provider)
 
-                    items = client.search(**search_params).item_collection()
+                    items = client.search(
+                        **base_params, collections=[provider.collection]
+                    ).item_collection()
                     if len(items) > 0:
                         return items, provider
                 except Exception as e:
@@ -164,7 +223,9 @@ class StacEndpointHandler:
                     )
                     continue
 
-            raise RuntimeError("No items found with any available STAC provider")
+            raise RuntimeError(
+                f"No items found with any available STAC provider for sensor '{sensor}'"
+            )
 
     def get_band_names(self, provider: StacMapping) -> Tuple[str, str]:
         """
@@ -189,3 +250,20 @@ class StacEndpointHandler:
             EPSG code as integer
         """
         return provider.epsg_code
+
+    def get_reflectance_scaling(self, provider: StacMapping) -> Tuple[float, float]:
+        """
+        Get the (scale, offset) needed to convert stored values to reflectance.
+
+        Surface-reflectance products are sometimes stored as scaled integers
+        (``reflectance = value * scale + offset``). Sentinel-2 L2A is already
+        reflectance, so its providers use the default no-op ``(1.0, 0.0)``.
+        Landsat Collection-2 Level-2 uses ``scale=0.0000275``, ``offset=-0.2``.
+
+        Args:
+            provider: The provider configuration
+
+        Returns:
+            Tuple of (scale, offset)
+        """
+        return provider.scale, provider.offset

--- a/src/stac/stac_endpoint_handler.py
+++ b/src/stac/stac_endpoint_handler.py
@@ -27,10 +27,13 @@ class StacMapping(BaseModel):
     Model for a single (sensor, provider) STAC mapping.
 
     The collection ID and band names are properties of the *(sensor, provider)*
-    pair, not of the provider alone, so they live together on this model. The
-    reflectance ``scale``/``offset`` default to a no-op; sensors whose surface
-    reflectance is stored as scaled integers (e.g. Landsat Collection-2 Level-2)
-    override them so values become comparable across sensors.
+    pair, not of the provider alone, so they live together on this model.
+
+    Reflectance scaling is intentionally NOT modeled here. stackstac applies the
+    per-asset ``scale``/``offset`` from each item's ``raster:bands`` metadata at
+    stack time (``rescale=True``), so reflectance correction — including
+    Landsat C2 L2's additive offset — comes from the providers' published
+    metadata rather than hardcoded per-sensor constants.
     """
 
     id: StacProvider
@@ -40,8 +43,6 @@ class StacMapping(BaseModel):
     swir_band: str
     nir_band: str
     epsg_code: int
-    scale: float = 1.0
-    offset: float = 0.0
 
 
 class SensorConfig(BaseModel):
@@ -113,8 +114,9 @@ class StacEndpointHandler:
     Handles interactions with STAC endpoints with fallback support.
 
     Tries multiple STAC endpoints in order of priority when data is not
-    available. Providers, their collection IDs, band names, and reflectance
-    scaling are all resolved per sensor from configuration.
+    available. Providers, their collection IDs, and band names are resolved
+    per sensor from configuration. Reflectance scaling is left to stackstac
+    (via each item's ``raster:bands`` metadata at stack time).
     """
 
     def __init__(
@@ -250,20 +252,3 @@ class StacEndpointHandler:
             EPSG code as integer
         """
         return provider.epsg_code
-
-    def get_reflectance_scaling(self, provider: StacMapping) -> Tuple[float, float]:
-        """
-        Get the (scale, offset) needed to convert stored values to reflectance.
-
-        Surface-reflectance products are sometimes stored as scaled integers
-        (``reflectance = value * scale + offset``). Sentinel-2 L2A is already
-        reflectance, so its providers use the default no-op ``(1.0, 0.0)``.
-        Landsat Collection-2 Level-2 uses ``scale=0.0000275``, ``offset=-0.2``.
-
-        Args:
-            provider: The provider configuration
-
-        Returns:
-            Tuple of (scale, offset)
-        """
-        return provider.scale, provider.offset

--- a/tests/commands/test_fire_severity_command.py
+++ b/tests/commands/test_fire_severity_command.py
@@ -270,7 +270,6 @@ class TestFireSeverityAnalysisCommand:
         )
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
-        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         # Mock stackstac.stack
         mock_data = xr.DataArray(
@@ -408,7 +407,6 @@ class TestFireSeverityAnalysisCommand:
         )
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
-        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         mock_data = xr.DataArray(
             np.random.random((4, 2, 10, 10)),

--- a/tests/commands/test_fire_severity_command.py
+++ b/tests/commands/test_fire_severity_command.py
@@ -112,7 +112,7 @@ def command_context(
         computation_config={
             "prefire_date_range": ["2023-06-01", "2023-06-15"],
             "postfire_date_range": ["2023-07-01", "2023-07-15"],
-            "collection": "sentinel-2-l2a",
+            "sensor": "sentinel-2",
             "buffer_meters": 100,
             "indices": ["nbr", "dnbr"],
         },
@@ -265,11 +265,12 @@ class TestFireSeverityAnalysisCommand:
         mock_handler.search_items = AsyncMock(
             return_value=(
                 ["item1", "item2"],  # Mock STAC items
-                {"nir_band": "B08", "swir_band": "B12", "epsg": 4326},  # Mock config
+                Mock(collection="sentinel-2-l2a"),  # Mock matched-provider config
             )
         )
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
+        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         # Mock stackstac.stack
         mock_data = xr.DataArray(
@@ -294,7 +295,7 @@ class TestFireSeverityAnalysisCommand:
             command_context.geometry,
             ["2023-06-01", "2023-06-15"],
             ["2023-07-01", "2023-07-15"],
-            "sentinel-2-l2a",
+            "sentinel-2",
             100.0,
         )
 
@@ -402,11 +403,12 @@ class TestFireSeverityAnalysisCommand:
         mock_handler.search_items = AsyncMock(
             return_value=(
                 ["item1", "item2"],
-                {"nir_band": "B08", "swir_band": "B12", "epsg": 4326},
+                Mock(collection="sentinel-2-l2a"),
             )
         )
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
+        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         mock_data = xr.DataArray(
             np.random.random((4, 2, 10, 10)),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -233,20 +233,21 @@ def realistic_stac_endpoint_mock():
         mock_handler = Mock()
 
         # Mock search_items to return realistic STAC items
-        async def mock_search_items(geometry, date_range, collections):
+        async def mock_search_items(geometry, date_range, sensor):
             # Create synthetic STAC items
             items = [
                 {"id": f"sentinel-2-l2a-{i}", "datetime": date}
                 for i, date in enumerate([*prefire_dates, *postfire_dates])
             ]
 
-            endpoint_config = {"nir_band": "B08", "swir_band": "B12", "epsg": 4326}
+            endpoint_config = Mock(collection="sentinel-2-l2a")
 
             return items, endpoint_config
 
         mock_handler.search_items = AsyncMock(side_effect=mock_search_items)
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
+        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         # Create combined date range for synthetic data
         all_dates = prefire_dates + postfire_dates
@@ -305,7 +306,7 @@ def create_integration_context(
         computation_config={
             "prefire_date_range": prefire_dates,
             "postfire_date_range": postfire_dates,
-            "collection": "sentinel-2-l2a",
+            "sensor": "sentinel-2",
             "buffer_meters": 100,
             "indices": ["dnbr", "rdnbr", "rbr"],
         },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -247,13 +247,12 @@ def realistic_stac_endpoint_mock():
         mock_handler.search_items = AsyncMock(side_effect=mock_search_items)
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
-        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         # Create combined date range for synthetic data
         all_dates = prefire_dates + postfire_dates
 
         # Mock stackstac.stack to return realistic synthetic data
-        def mock_stackstac_stack(items, epsg, assets, bounds, chunksize):
+        def mock_stackstac_stack(items, epsg, assets, bounds, chunksize, rescale=True):
             return create_realistic_satellite_data(
                 geometry_bounds, all_dates, burn_pattern
             )

--- a/tests/stac/test_stac_endpoint_handler.py
+++ b/tests/stac/test_stac_endpoint_handler.py
@@ -4,6 +4,10 @@ These tests exercise configuration parsing and the per-provider accessors only
 (no network calls): the shipped config is loaded and inspected, the model is
 validated directly, and the unknown-sensor / unknown-provider error paths are
 covered with synthetic configs.
+
+Reflectance scaling is deliberately NOT tested here because it is not our
+concern: stackstac applies the per-asset scale/offset from each item's
+``raster:bands`` metadata at stack time (``rescale=True``).
 """
 
 import json
@@ -41,19 +45,13 @@ class TestStacProviderConfigLoading:
         assert len(providers) == 2
         for provider in providers:
             assert provider.collection == "sentinel-2-l2a"
-            # Sentinel-2 L2A is already surface reflectance: no rescaling.
-            assert provider.scale == 1.0
-            assert provider.offset == 0.0
 
-    def test_landsat_providers_use_landsat_collection_and_scaling(self) -> None:
+    def test_landsat_providers_use_landsat_collection_and_bands(self) -> None:
         config = StacProviderConfig.load_from_file()
         providers = config.get_providers("landsat")
         assert len(providers) >= 1
         for provider in providers:
             assert provider.collection == "landsat-c2-l2"
-            # USGS Collection-2 Level-2 surface-reflectance scaling.
-            assert provider.scale == pytest.approx(0.0000275)
-            assert provider.offset == pytest.approx(-0.2)
             # NBR uses NIR (B5, ~0.86um) and SWIR (B7, ~2.2um).
             assert provider.nir_band == "nir08"
             assert provider.swir_band == "swir22"
@@ -113,18 +111,6 @@ class TestStacEndpointHandler:
         assert nir == "nir08"
         assert swir == "swir22"
 
-    def test_reflectance_scaling_sentinel2_is_noop(self) -> None:
-        handler = StacEndpointHandler()
-        provider = handler.config.get_providers("sentinel-2")[0]
-        assert handler.get_reflectance_scaling(provider) == (1.0, 0.0)
-
-    def test_reflectance_scaling_landsat(self) -> None:
-        handler = StacEndpointHandler()
-        provider = handler.config.get_providers("landsat")[0]
-        scale, offset = handler.get_reflectance_scaling(provider)
-        assert scale == pytest.approx(0.0000275)
-        assert offset == pytest.approx(-0.2)
-
     def test_epsg_accessor(self) -> None:
         handler = StacEndpointHandler()
         provider = handler.config.get_providers("sentinel-2")[0]
@@ -134,7 +120,7 @@ class TestStacEndpointHandler:
 class TestSensorConfigModel:
     """Direct validation of the pydantic models."""
 
-    def test_stac_mapping_defaults_scale_offset(self) -> None:
+    def test_stac_mapping_fields(self) -> None:
         mapping = StacMapping(
             id=StacProvider.ELEMENT_84,
             name="Element 84",
@@ -144,8 +130,8 @@ class TestSensorConfigModel:
             nir_band="nir08",
             epsg_code=4326,
         )
-        assert mapping.scale == 1.0
-        assert mapping.offset == 0.0
+        assert mapping.collection == "sentinel-2-l2a"
+        assert mapping.id is StacProvider.ELEMENT_84
 
     def test_sensor_config_holds_providers(self) -> None:
         sensor_config = SensorConfig(
@@ -158,8 +144,6 @@ class TestSensorConfigModel:
                     swir_band="swir22",
                     nir_band="nir08",
                     epsg_code=4326,
-                    scale=0.0000275,
-                    offset=-0.2,
                 )
             ]
         )

--- a/tests/stac/test_stac_endpoint_handler.py
+++ b/tests/stac/test_stac_endpoint_handler.py
@@ -1,0 +1,167 @@
+"""Tests for the sensor-aware STAC endpoint configuration and handler.
+
+These tests exercise configuration parsing and the per-provider accessors only
+(no network calls): the shipped config is loaded and inspected, the model is
+validated directly, and the unknown-sensor / unknown-provider error paths are
+covered with synthetic configs.
+"""
+
+import json
+
+import pytest
+
+from src.stac.stac_endpoint_handler import (
+    DEFAULT_SENSOR,
+    SensorConfig,
+    StacEndpointHandler,
+    StacMapping,
+    StacProvider,
+    StacProviderConfig,
+)
+
+
+class TestStacProviderConfigLoading:
+    """Loading and parsing of the sensor-keyed provider configuration."""
+
+    def test_shipped_config_exposes_both_sensors(self) -> None:
+        config = StacProviderConfig.load_from_file()
+        sensors = config.get_sensors()
+        assert "sentinel-2" in sensors
+        assert "landsat" in sensors
+
+    def test_default_sensor_is_sentinel_2(self) -> None:
+        assert DEFAULT_SENSOR == "sentinel-2"
+        config = StacProviderConfig.load_from_file()
+        # get_providers() defaults to the module default sensor.
+        assert config.get_providers() == config.get_providers("sentinel-2")
+
+    def test_sentinel2_providers_use_sentinel_collection(self) -> None:
+        config = StacProviderConfig.load_from_file()
+        providers = config.get_providers("sentinel-2")
+        assert len(providers) == 2
+        for provider in providers:
+            assert provider.collection == "sentinel-2-l2a"
+            # Sentinel-2 L2A is already surface reflectance: no rescaling.
+            assert provider.scale == 1.0
+            assert provider.offset == 0.0
+
+    def test_landsat_providers_use_landsat_collection_and_scaling(self) -> None:
+        config = StacProviderConfig.load_from_file()
+        providers = config.get_providers("landsat")
+        assert len(providers) >= 1
+        for provider in providers:
+            assert provider.collection == "landsat-c2-l2"
+            # USGS Collection-2 Level-2 surface-reflectance scaling.
+            assert provider.scale == pytest.approx(0.0000275)
+            assert provider.offset == pytest.approx(-0.2)
+            # NBR uses NIR (B5, ~0.86um) and SWIR (B7, ~2.2um).
+            assert provider.nir_band == "nir08"
+            assert provider.swir_band == "swir22"
+
+    def test_provider_id_parsed_to_enum(self) -> None:
+        config = StacProviderConfig.load_from_file()
+        ids = {p.id for p in config.get_providers("sentinel-2")}
+        assert StacProvider.ELEMENT_84 in ids
+        assert StacProvider.MICROSOFT_PLANETARY_COMPUTER in ids
+
+    def test_unknown_sensor_raises_value_error(self) -> None:
+        config = StacProviderConfig.load_from_file()
+        with pytest.raises(ValueError, match="Unknown sensor"):
+            config.get_providers("modis")
+
+    def test_unknown_provider_id_raises_value_error(self, tmp_path) -> None:
+        bad_config = {
+            "sensors": {
+                "sentinel-2": {
+                    "providers": [
+                        {
+                            "id": "NOT_A_REAL_PROVIDER",
+                            "name": "Bogus",
+                            "url": "https://example.com",
+                            "collection": "sentinel-2-l2a",
+                            "swir_band": "B12",
+                            "nir_band": "B8A",
+                            "epsg_code": 4326,
+                        }
+                    ]
+                }
+            }
+        }
+        path = tmp_path / "bad_providers.json"
+        path.write_text(json.dumps(bad_config))
+        with pytest.raises(ValueError, match="Unknown provider"):
+            StacProviderConfig.load_from_file(str(path))
+
+    def test_missing_file_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            StacProviderConfig.load_from_file("config/does_not_exist.json")
+
+
+class TestStacEndpointHandler:
+    """The handler wraps the config and exposes per-provider accessors."""
+
+    def test_handler_exposes_both_sensors(self) -> None:
+        handler = StacEndpointHandler()
+        sensors = handler.get_sensors()
+        assert "sentinel-2" in sensors
+        assert "landsat" in sensors
+
+    def test_band_names_accessor(self) -> None:
+        handler = StacEndpointHandler()
+        landsat_provider = handler.config.get_providers("landsat")[0]
+        nir, swir = handler.get_band_names(landsat_provider)
+        assert nir == "nir08"
+        assert swir == "swir22"
+
+    def test_reflectance_scaling_sentinel2_is_noop(self) -> None:
+        handler = StacEndpointHandler()
+        provider = handler.config.get_providers("sentinel-2")[0]
+        assert handler.get_reflectance_scaling(provider) == (1.0, 0.0)
+
+    def test_reflectance_scaling_landsat(self) -> None:
+        handler = StacEndpointHandler()
+        provider = handler.config.get_providers("landsat")[0]
+        scale, offset = handler.get_reflectance_scaling(provider)
+        assert scale == pytest.approx(0.0000275)
+        assert offset == pytest.approx(-0.2)
+
+    def test_epsg_accessor(self) -> None:
+        handler = StacEndpointHandler()
+        provider = handler.config.get_providers("sentinel-2")[0]
+        assert handler.get_epsg_code(provider) == 4326
+
+
+class TestSensorConfigModel:
+    """Direct validation of the pydantic models."""
+
+    def test_stac_mapping_defaults_scale_offset(self) -> None:
+        mapping = StacMapping(
+            id=StacProvider.ELEMENT_84,
+            name="Element 84",
+            url="https://example.com",
+            collection="sentinel-2-l2a",
+            swir_band="swir22",
+            nir_band="nir08",
+            epsg_code=4326,
+        )
+        assert mapping.scale == 1.0
+        assert mapping.offset == 0.0
+
+    def test_sensor_config_holds_providers(self) -> None:
+        sensor_config = SensorConfig(
+            providers=[
+                StacMapping(
+                    id=StacProvider.ELEMENT_84,
+                    name="Element 84",
+                    url="https://example.com",
+                    collection="landsat-c2-l2",
+                    swir_band="swir22",
+                    nir_band="nir08",
+                    epsg_code=4326,
+                    scale=0.0000275,
+                    offset=-0.2,
+                )
+            ]
+        )
+        assert len(sensor_config.providers) == 1
+        assert sensor_config.providers[0].collection == "landsat-c2-l2"

--- a/tests/test_multipolygon_integration.py
+++ b/tests/test_multipolygon_integration.py
@@ -210,7 +210,6 @@ class TestFireSeverityAnalysisWithMultiPolygon:
         )
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
-        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         mock_data = xr.DataArray(
             np.random.random((4, 2, 10, 10)),
@@ -561,7 +560,6 @@ class TestBackwardCompatibility:
         )
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
-        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         mock_data = xr.DataArray(
             np.random.random((2, 2, 10, 10)),

--- a/tests/test_multipolygon_integration.py
+++ b/tests/test_multipolygon_integration.py
@@ -193,7 +193,7 @@ class TestFireSeverityAnalysisWithMultiPolygon:
             computation_config={
                 "prefire_date_range": ["2023-06-01", "2023-06-15"],
                 "postfire_date_range": ["2023-07-01", "2023-07-15"],
-                "collection": "sentinel-2-l2a",
+                "sensor": "sentinel-2",
                 "buffer_meters": 100,
                 "indices": ["nbr", "dnbr"],
             },
@@ -205,11 +205,12 @@ class TestFireSeverityAnalysisWithMultiPolygon:
         mock_handler.search_items = AsyncMock(
             return_value=(
                 ["item1", "item2"],
-                {"nir_band": "B08", "swir_band": "B12", "epsg": 4326},
+                Mock(collection="sentinel-2-l2a"),
             )
         )
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
+        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         mock_data = xr.DataArray(
             np.random.random((4, 2, 10, 10)),
@@ -543,7 +544,7 @@ class TestBackwardCompatibility:
             computation_config={
                 "prefire_date_range": ["2023-06-01", "2023-06-15"],
                 "postfire_date_range": ["2023-07-01", "2023-07-15"],
-                "collection": "sentinel-2-l2a",
+                "sensor": "sentinel-2",
                 "buffer_meters": 100,
                 "indices": ["nbr"],
             },
@@ -555,11 +556,12 @@ class TestBackwardCompatibility:
         mock_handler.search_items = AsyncMock(
             return_value=(
                 ["item1"],
-                {"nir_band": "B08", "swir_band": "B12", "epsg": 4326},
+                Mock(collection="sentinel-2-l2a"),
             )
         )
         mock_handler.get_band_names.return_value = ("B08", "B12")
         mock_handler.get_epsg_code.return_value = 4326
+        mock_handler.get_reflectance_scaling.return_value = (1.0, 0.0)
 
         mock_data = xr.DataArray(
             np.random.random((2, 2, 10, 10)),


### PR DESCRIPTION
## Summary

Adds **Landsat** as a selectable satellite source alongside Sentinel-2 (previously the only option). The source is chosen via an optional `sensor` body field on `POST /process/analyze_fire_severity` — default `sentinel-2`, so existing clients are unaffected (verified: a request omitting `sensor` resolves to `sentinel-2` at every layer).

## Changes
- **`config/stac_providers.json`** — restructured flat provider list → **sensor-keyed**; collection ID moved into config; added a `landsat` sensor (`landsat-c2-l2`). Landsat provider order is **[Planetary Computer, Element 84]** (see data-access note); Sentinel-2 stays **[Element 84, PC]**.
- **`StacEndpointHandler`** — `SensorConfig` + sensor-keyed `StacProviderConfig`; `search_items(sensor=...)` resolves the collection per provider and preserves the per-sensor fallback chain; adds `get_sensors()` and `DEFAULT_SENSOR`.
- **Request / router / command** — `Sensor` literal + optional `sensor` field threaded through into the command.

## Reflectance scaling — handled by provider metadata, not by us
Landsat C2 L2 surface reflectance is stored as scaled integers (`value * 2.75e-05 - 0.2`). NBR is a normalized difference, so the multiplicative scale cancels but the **additive offset does not** — the offset must be applied or Landsat dNBR/RBR aren't comparable to Sentinel-2.

We do **not** apply this ourselves. `stackstac.stack(rescale=True)` (default, now explicit) reads each asset's `raster:bands` `scale`/`offset` from STAC metadata and applies it at stack time, also masking nodata to NaN. Verified against live items: `landsat-c2-l2` → `{2.75e-05, -0.2}`, `sentinel-2-l2a` → `{1e-04, -0.1}`.

> An earlier commit on this branch hand-rolled the unscaling in the command; that double-applied for Landsat and was removed. We now rely on the providers' metadata.

## Testing
- Full suite: **404 passed, 25 skipped, 0 failed**; ruff clean. The optional `sensor` field is non-breaking (contract suite passes; baseline unchanged).
- **Live cross-sensor run** (2021 Dixie Fire scar, both sensors on a shared ~111 m grid):

  | | Sentinel-2 (Element 84) | Landsat (PC) |
  |---|---|---|
  | raw DN mean (`rescale=False`) | 2,608 | 15,416 |
  | reflectance mean (`rescale=True`) | 0.164 | 0.142 |
  | NBR pre / post | +0.52 / −0.03 | +0.59 / +0.04 |
  | **dNBR mean** | **+0.552** | **+0.545** |
  | fraction dNBR>0.27 | 67% | 67% |

  Per-pixel **dNBR correlation r = 0.87**, mean |Δ| = 0.08. Landsat's scaled-integer DN (~15k) correctly becomes reflectance (~0.14) via stackstac, and the burn signal matches Sentinel-2 — confirming cross-sensor comparability and that the rescale path (not hand-rolled math) is doing the right thing.

## Follow-ups / open risks
- **Landsat data access.** The two providers catalog the same Landsat collection but the pixels live in different buckets: Element 84 points at the **requester-pays** `usgs-landsat` S3 bucket (anonymous reads 403; egress billed to the caller, and cross-cloud from GCP), while Planetary Computer re-hosts it in Azure **free** via signed URLs. The chain is **PC-first** so the free source wins; Element 84 stays a fallback that only works where requester-pays AWS access is configured.
- **PC is intermittently flaky.** During testing PC's STAC API failed (timeouts / error pages) for a stretch — for *both* collections — then recovered and served Landsat fine. Sentinel-2 is insulated because its primary is Element 84 (consistently reliable + free); Landsat rides on PC, so worth monitoring / having a plan if PC is degraded.
- Consider whether Landsat needs a different temporal window (longer revisit) than the reused Sentinel-2 date logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)