### PR TITLE
docs: correct per-sensor STAC provider order in ENDPOINTS.md

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -38,7 +38,7 @@ Initiates fire severity analysis using Sentinel-2 (default) or Landsat satellite
 
 #### Processing Pipeline
 
-1. Queries the selected sensor's collection — Sentinel-2 L2A or Landsat C2 L2 — from STAC (Element 84 primary, Microsoft Planetary Computer fallback)
+1. Queries the selected sensor's collection from STAC, with per-sensor provider fallback: Sentinel-2 L2A via Element 84 (then Microsoft Planetary Computer); Landsat C2 L2 via Microsoft Planetary Computer (then Element 84)
 2. Creates temporal median composites for pre-fire and post-fire periods
 3. Calculates spectral indices:
    - **NBR** (Normalized Burn Ratio): `(NIR - SWIR) / (NIR + SWIR)`


### PR DESCRIPTION
Follow-up to #18. The fire-severity pipeline description in `docs/ENDPOINTS.md` said providers are tried "Element 84 primary, Microsoft Planetary Computer fallback" — accurate for Sentinel-2, but **Landsat** uses the reverse order (PC first) since Element 84's Landsat lives in the requester-pays `usgs-landsat` bucket while PC re-hosts it free. Updated to state the order per sensor.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)